### PR TITLE
expose ignore_submodules in extract_nir_graph

### DIFF
--- a/nirtorch/to_nir.py
+++ b/nirtorch/to_nir.py
@@ -12,6 +12,7 @@ def extract_nir_graph(
     model_map: Callable[[nn.Module], nir.NIRNode],
     sample_data: Any,
     model_name: Optional[str] = "model",
+    ignore_submodules_of=None
 ) -> nir.NIRNode:
     """Given a `model`, generate an NIR representation using the specified `model_map`.
 
@@ -35,6 +36,9 @@ def extract_nir_graph(
     torch_graph = extract_torch_graph(
         model, sample_data=sample_data, model_name=model_name
     ).ignore_tensors()
+
+    if ignore_submodules_of is not None:
+        torch_graph = torch_graph.ignore_submodules_of(ignore_submodules_of)
 
     # Get the root node
     root_nodes = torch_graph.get_root()


### PR DESCRIPTION
to support RNN models in snnTorch, we can simply ignore all submodules within the `RLeaky` or `RSynaptic` modules, since we will handle them manually directly in snnTorch. 

We then use NIRTorch as follows from within snnTorch to extract a NIR graph:
```python
return extract_nir_graph(
        module, _extract_snntorch_module, sample_data, model_name=model_name,
        ignore_submodules_of=[RLeaky, RSynaptic]
    )
```