### PR TITLE
Fixed parsing of inputs for subgraphs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          ruff --output-format=github --select=E9,F63,F7,F82 --target-version=py37 .
+          ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py37 .
           # default set of ruff rules with GitHub Annotations
-          ruff --output-format=github --target-version=py37 .
+          ruff check --output-format=github --target-version=py37 .
       - name: Test with pytest
         run: |
           pytest

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688764204,
-        "narHash": "sha256-FsvK+tIvelCI0tWwlMDKfiyb7P/KfxpGbXMrdCKiT8s=",
+        "lastModified": 1719145550,
+        "narHash": "sha256-K0i/coxxTEl30tgt4oALaylQfxqbotTSNb1/+g+mKMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d8bb6c681cf86265fdcf3cc3119f757bbb085835",
+        "rev": "e4509b3a560c87a8d4cb6f9992b8915abf9e36d8",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-23.05",
+        "ref": "nixos-24.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Neuromorphic Intermediate Representation PyTorch graph analysis layer"; 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-23.05";
+    nixpkgs.url = "nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:

--- a/nirtorch/from_nir.py
+++ b/nirtorch/from_nir.py
@@ -1,201 +1,51 @@
 import dataclasses
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import nir
 import torch
 import torch.nn as nn
 
-from .graph import Graph, Node
-from .graph_utils import trace_execution
+from .graph import TorchGraph
+from .graph_executor import GraphExecutor
 from .utils import sanitize_name
 
 
-@dataclasses.dataclass
-class GraphExecutorState:
-    """State for the GraphExecutor that keeps track of both the state of hidden units
-    and caches the output of previous modules, for use in (future) recurrent
-    computations."""
-
-    state: Dict[str, Any] = dataclasses.field(default_factory=dict)
-    cache: Dict[str, Any] = dataclasses.field(default_factory=dict)
-
-
-class GraphExecutor(nn.Module):
-    """Executes the NIR graph in PyTorch.
-
-    By default the graph executor is stateful, since there may be recurrence or
-    stateful modules in the graph. Specifically, that means accepting and returning a
-    state object (`GraphExecutorState`). If that is not desired,
-    set `return_state=False` in the constructor.
-
-    Arguments:
-        graph (Graph): The graph to execute
-        return_state (bool, optional): Whether to return the state object.
-            Defaults to True.
-
-    Raises:
-        ValueError: If there are no edges in the graph
-    """
-
-    def __init__(self, graph: Graph, return_state: bool = True) -> None:
-        super().__init__()
-        self.graph = graph
-        self.stateful_modules = set()
-        self.return_state = return_state
-        self.instantiate_modules()
-        self.execution_order = self.get_execution_order()
-        if len(self.execution_order) == 0:
-            raise ValueError("Graph is empty")
-
-    def _is_module_stateful(self, module: torch.nn.Module) -> bool:
-        signature = inspect.signature(module.forward)
-        arguments = len(signature.parameters)
-        # HACK for snntorch modules
-        if "snntorch" in str(module.__class__):
-            if module.__class__.__name__ in [
-                "Synaptic",
-                "RSynaptic",
-                "Leaky",
-                "RLeaky",
-            ]:
-                return not module.init_hidden
-        return "state" in signature.parameters and arguments > 1
-
-    def get_execution_order(self) -> List[Node]:
-        """Evaluate the execution order and instantiate that as a list."""
-        # TODO: Adapt this for graphs with multiple inputs
-        inputs = self.graph.inputs
-        if len(inputs) != 1:
-            raise ValueError(
-                f"Currently, only one input is supported, but {len(inputs)} was given"
-            )
-        return trace_execution(inputs[0], lambda n: n.outgoing_nodes.keys())
-
-    def instantiate_modules(self):
-        for mod, name in self.graph.module_names.items():
-            if mod is not None:
-                self.add_module(sanitize_name(name), mod)
-                if self._is_module_stateful(mod):
-                    self.stateful_modules.add(sanitize_name(name))
-
-    def get_input_nodes(self) -> List[Node]:
-        # NOTE: This is a hack. Should use the input nodes from NIR graph
-        return self.graph.get_root()
-
-    def _apply_module(
-        self,
-        node: Node,
-        input_nodes: List[Node],
-        new_state: GraphExecutorState,
-        old_state: GraphExecutorState,
-        data: Optional[torch.Tensor] = None,
-    ):
-        """Applies a module and keeps track of its state.
-
-        TODO: Use pytree to recursively construct the state
-        """
-        inputs = []
-        # Append state if needed
-        if node.name in self.stateful_modules and node.name in old_state.state:
-            inputs.extend(old_state.state[node.name])
-
-        # Sum recurrence if needed
-        summed_inputs = [] if data is None else [data]
-        for input_node in input_nodes:
-            if (
-                input_node.name not in new_state.cache
-                and input_node.name in old_state.cache
-            ):
-                summed_inputs.append(old_state.cache[input_node.name])
-            elif input_node.name in new_state.cache:
-                summed_inputs.append(new_state.cache[input_node.name])
-
-        if len(summed_inputs) == 0:
-            raise ValueError("No inputs found for node {}".format(node.name))
-        elif len(summed_inputs) == 1:
-            inputs.insert(0, summed_inputs[0])
-        elif len(summed_inputs) > 1:
-            inputs.insert(0, torch.stack(summed_inputs).sum(0))
-
-        out = node.elem(*inputs)
-        # If the module is stateful, we know the output is (at least) a tuple
-        # HACK to make it work for snnTorch
-        is_rsynaptic = "snntorch._neurons.rsynaptic.RSynaptic" in str(
-            node.elem.__class__
-        )
-        if is_rsynaptic and not node.elem.init_hidden:
-            assert "lif" in node.name, "this shouldnt happen.."
-            new_state.state[node.name] = out  # snnTorch requires output inside state
-            out = out[0]
-        elif node.name in self.stateful_modules:
-            new_state.state[node.name] = out[1:]  # Store the new state
-            out = out[0]
-        return out, new_state
-
-    def forward(
-        self, data: torch.Tensor, old_state: Optional[GraphExecutorState] = None
-    ):
-        if old_state is None:
-            old_state = GraphExecutorState()
-        new_state = GraphExecutorState()
-        first_node = True
-        # NOTE: This logic is not yet consistent for models with multiple input nodes
-        for node in self.execution_order:
-            input_nodes = self.graph.find_source_nodes_of(node)
-            if node.elem is None:
-                continue
-            out, new_state = self._apply_module(
-                node,
-                input_nodes,
-                new_state=new_state,
-                old_state=old_state,
-                data=data if first_node else None,
-            )
-            new_state.cache[node.name] = out
-            first_node = False
-
-        # If the output node is a dummy nir.Output node, use the second-to-last node
-        if node.name not in new_state.cache:
-            node = self.execution_order[-2]
-        if self.return_state:
-            return new_state.cache[node.name], new_state
-        else:
-            return new_state.cache[node.name]
-
-
-def _mod_nir_to_graph(
-    torch_graph: nir.NIRGraph, nir_nodes: Dict[str, nir.NIRNode]
-) -> Graph:
-    module_names = {module: name for name, module in torch_graph.nodes.items()}
-    inputs = [name for name, node in nir_nodes.items() if isinstance(node, nir.Input)]
-    graph = Graph(module_names=module_names, inputs=inputs)
-    for src, dst in torch_graph.edges:
-        # Allow edges to refer to subgraph inputs and outputs
-        if src not in torch_graph.nodes and f"{src}.output" in torch_graph.nodes:
-            src = f"{src}.output"
-        if dst not in torch_graph.nodes and f"{dst}.input" in torch_graph.nodes:
-            dst = f"{dst}.input"
-        graph.add_edge(torch_graph.nodes[src], torch_graph.nodes[dst])
-    return graph
-
-
 def _switch_default_models(nir_graph: nir.NIRNode) -> Optional[torch.nn.Module]:
-    if isinstance(nir_graph, nir.Input) or isinstance(nir_graph, nir.Output):
-        return torch.nn.Identity()
+    node = None
+    if isinstance(nir_graph, nir.Input):
+        node = torch.nn.Identity()
+        node.node_type = "input"
+    elif isinstance(nir_graph, nir.Output):
+        node = torch.nn.Identity()
+        node.node_type = "output"
+    return node
 
 
-def _switch_models_with_map(
-    nir_graph: nir.NIRNode, model_map: Callable[[nn.Module], nn.Module]
+def _map_graph_to_torch(
+    nir_graph: nir.NIRNode,
+    model_map: Callable[[nn.Module], nn.Module],
+    return_state: bool = True,
 ) -> nir.NIRNode:
     nodes = {}
     for name, node in nir_graph.nodes.items():
         mapped_module = model_map(node)
         if mapped_module is None:
-            mapped_module = _switch_default_models(node)
-        nodes[name] = mapped_module
-    # nodes = {name: model_map(node) for name, node in nir_graph.nodes.items()}
-    return nir.NIRGraph(nodes, nir_graph.edges)
+            if isinstance(node, nir.NIRGraph):  # Recurse
+                mapped_module = _map_graph_to_torch(node, model_map, return_state)
+            else:  # Map identity nodes (input, output, etc.)
+                mapped_module = _switch_default_models(node)
+        nodes[sanitize_name(name)] = mapped_module
+    # Ensure that we use legal PyTorch names for the edges
+    sanitized_edges = [
+        (sanitize_name(src), sanitize_name(dst)) for src, dst in nir_graph.edges
+    ]
+    # Reconstruct NIR graph with torch modules
+    recon_graph = nir.NIRGraph(nodes, sanitized_edges)
+    # Build a TorchGraph for tracing and executing
+    trace_graph = TorchGraph.from_torch_modules(recon_graph.nodes, recon_graph.edges)
+    # Build and return a graph executor module
+    return GraphExecutor(trace_graph, return_state=return_state)
 
 
 def load(
@@ -231,9 +81,5 @@ def load(
     """
     if isinstance(nir_graph, str):
         nir_graph = nir.read(nir_graph)
-    # Map modules to the target modules using th emodel map
-    nir_module_graph = _switch_models_with_map(nir_graph, model_map)
-    # Build a nirtorch.Graph based on the nir_graph
-    graph = _mod_nir_to_graph(nir_module_graph, nir_nodes=nir_graph.nodes)
-    # Build and return a graph executor module
-    return GraphExecutor(graph, return_state=return_state)
+    # Convert the NIR graph to a torch graph
+    return _map_graph_to_torch(nir_graph, model_map, return_state=return_state)

--- a/nirtorch/from_nir.py
+++ b/nirtorch/from_nir.py
@@ -1,6 +1,4 @@
-import dataclasses
-import inspect
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Callable, Optional, Union
 
 import nir
 import torch

--- a/nirtorch/graph.py
+++ b/nirtorch/graph.py
@@ -1,5 +1,4 @@
 import warnings
-from collections import defaultdict
 from numbers import Number
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 

--- a/nirtorch/graph_executor.py
+++ b/nirtorch/graph_executor.py
@@ -1,0 +1,171 @@
+import dataclasses
+import inspect
+import logging
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch import nn
+
+from .graph import TorchGraph, Node
+from .graph_utils import trace_execution
+from .utils import sanitize_name
+
+
+@dataclasses.dataclass
+class GraphExecutorState:
+    """State for the GraphExecutor that keeps track of both the state of hidden units
+    and caches the output of previous modules, for use in (future) recurrent
+    computations."""
+
+    state: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    cache: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+class GraphExecutor(nn.Module):
+    """Executes the NIR graph in PyTorch.
+
+    By default the graph executor is stateful, since there may be recurrence or
+    stateful modules in the graph. Specifically, that means accepting and returning a
+    state object (`GraphExecutorState`). If that is not desired,
+    set `return_state=False` in the constructor.
+
+    Arguments:
+        graph (Graph): The graph to execute
+        return_state (bool, optional): Whether to return the state object.
+            Defaults to True.
+
+    Raises:
+        ValueError: If there are no edges in the graph
+    """
+
+    def __init__(self, graph: TorchGraph, return_state: bool = True) -> None:
+        super().__init__()
+        self.graph = graph
+        self.stateful_modules = set()
+        self.return_state = return_state
+        self.instantiate_modules()
+        self.execution_order = self.get_execution_order()
+        if len(self.execution_order) == 0:
+            raise ValueError("Graph is empty")
+
+    def _is_module_stateful(self, module: torch.nn.Module) -> bool:
+        signature = inspect.signature(module.forward)
+        arguments = len(signature.parameters)
+        # HACK for snntorch modules
+        if "snntorch" in str(module.__class__):
+            if module.__class__.__name__ in [
+                "Synaptic",
+                "RSynaptic",
+                "Leaky",
+                "RLeaky",
+            ]:
+                return not module.init_hidden
+        # Note that GraphExecutor is *also* a stateful module
+        return "state" in signature.parameters and arguments > 1
+
+    def get_execution_order(self) -> List[Node]:
+        """Evaluate the execution order and instantiate that as a list."""
+        inputs = set()
+        name_dict = {name: node for node, name in self.graph.module_names.items()}
+        for input_node in self.graph.inputs:
+            if input_node.name in name_dict:
+                inputs.add(input_node)
+            else:
+                logging.warning(
+                    f"Input node {input_node.name} not found in module names. Skipping."
+                )
+        assert len(inputs) > 0, "No input nodes found, we require at least one."
+        if len(inputs) > 1:
+            logging.warning(
+                "Multiple input nodes found. Using the first node as the input."
+            )
+        return trace_execution(next(iter(inputs)), lambda n: n.outgoing_nodes.keys())
+
+    def instantiate_modules(self):
+        for mod, name in self.graph.module_names.items():
+            if mod is not None:
+                self.add_module(sanitize_name(name), mod)
+                if self._is_module_stateful(mod):
+                    self.stateful_modules.add(sanitize_name(name))
+
+    def get_input_nodes(self) -> List[Node]:
+        # NOTE: This is a hack. Should use the input nodes from NIR graph
+        return self.graph.get_root()
+
+    def _apply_module(
+        self,
+        node: Node,
+        input_nodes: List[Node],
+        new_state: GraphExecutorState,
+        old_state: GraphExecutorState,
+        data: Optional[torch.Tensor] = None,
+    ):
+        """Applies a module and keeps track of its state.
+
+        TODO: Use pytree to recursively construct the state
+        """
+        inputs = []
+        # Append state if needed
+        if node.name in self.stateful_modules and node.name in old_state.state:
+            inputs.extend(old_state.state[node.name])
+
+        # Sum recurrence if needed
+        summed_inputs = [] if data is None else [data]
+        for input_node in input_nodes:
+            if (
+                input_node.name not in new_state.cache
+                and input_node.name in old_state.cache
+            ):
+                summed_inputs.append(old_state.cache[input_node.name])
+            elif input_node.name in new_state.cache:
+                summed_inputs.append(new_state.cache[input_node.name])
+
+        if len(summed_inputs) == 0:
+            raise ValueError("No inputs found for node {}".format(node.name))
+        elif len(summed_inputs) == 1:  # Prepend the input
+            inputs.insert(0, summed_inputs[0])
+        elif len(summed_inputs) > 1:  # Prepend the sum of the inputs
+            inputs.insert(0, torch.stack(summed_inputs).sum(0))
+
+        out = node.elem(*inputs)
+        # If the module is stateful, we know the output is (at least) a tuple
+        # HACK to make it work for snnTorch
+        is_rsynaptic = "snntorch._neurons.rsynaptic.RSynaptic" in str(
+            node.elem.__class__
+        )
+        if is_rsynaptic and not node.elem.init_hidden:
+            assert "lif" in node.name, "this shouldnt happen.."
+            new_state.state[node.name] = out  # snnTorch requires output inside state
+            out = out[0]
+        elif node.name in self.stateful_modules:
+            new_state.state[node.name] = out[1:]  # Store the new state
+            out = out[0]
+        return out, new_state
+
+    def forward(self, data: torch.Tensor, state: Optional[GraphExecutorState] = None):
+        if state is None:
+            state = GraphExecutorState()
+        new_state = GraphExecutorState()
+        first_node = True
+        # NOTE: This logic is not yet consistent for models with multiple input nodes
+        for node in self.execution_order:
+            input_nodes = self.graph.find_source_nodes_of(node)
+            if node.elem is None:
+                continue
+            out, new_state = self._apply_module(
+                node,
+                input_nodes,
+                new_state=new_state,
+                old_state=state,
+                data=data if first_node else None,
+            )
+            new_state.cache[node.name] = out
+            first_node = False
+
+        # If the output node is a dummy nir.Output node, use the second-to-last node
+        if node.name not in new_state.cache:
+            node = self.execution_order[-2]
+        if self.return_state:
+            return new_state.cache[node.name], new_state
+        else:
+            return new_state.cache[node.name]

--- a/nirtorch/graph_utils.py
+++ b/nirtorch/graph_utils.py
@@ -1,5 +1,7 @@
 from typing import Callable, List, Set, TypeVar
 
+from torch import nn
+
 T = TypeVar("T")
 
 
@@ -84,3 +86,11 @@ def trace_execution(
         if child not in visited:
             successors += trace_execution(child, edge_fn, visited)
     return [node] + successors
+
+
+class GraphInputNode(nn.Module):
+    pass
+
+
+class GraphOutputNode(nn.Module):
+    pass

--- a/nirtorch/to_nir.py
+++ b/nirtorch/to_nir.py
@@ -47,7 +47,7 @@ def extract_nir_graph(
     # Extract a torch graph given the model
     torch_graph = extract_torch_graph(
         model, sample_data=sample_data, model_name=model_name, model_args=model_fwd_args
-    ).ignore_tensors()
+    )
 
     if ignore_submodules_of is not None:
         torch_graph = torch_graph.ignore_submodules_of(ignore_submodules_of)

--- a/tests/test_from_nir.py
+++ b/tests/test_from_nir.py
@@ -4,7 +4,6 @@ import pytest
 import torch
 
 from nirtorch.from_nir import load
-from nirtorch import graph
 
 
 def _torch_model_map(m: nir.NIRNode, device: str = "cpu") -> torch.nn.Module:

--- a/tests/test_from_nir.py
+++ b/tests/test_from_nir.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from nirtorch.from_nir import load
+from nirtorch import graph
 
 
 def _torch_model_map(m: nir.NIRNode, device: str = "cpu") -> torch.nn.Module:
@@ -18,8 +19,6 @@ def _torch_model_map(m: nir.NIRNode, device: str = "cpu") -> torch.nn.Module:
         return lin
     elif isinstance(m, nir.Input) or isinstance(m, nir.Output):
         return torch.nn.Identity()
-    else:
-        raise NotImplementedError(f"Unsupported module {m}")
 
 
 def _recurrent_model_map(m: nir.NIRNode, device: str = "cpu") -> torch.nn.Module:
@@ -36,8 +35,10 @@ def _recurrent_model_map(m: nir.NIRNode, device: str = "cpu") -> torch.nn.Module
             return self.lin(z), z
 
     try:
-        return _torch_model_map(m, device)
+        mapped_model = _torch_model_map(m, device)
     except NotImplementedError:
+        mapped_model = None
+    if mapped_model is None:
         if isinstance(m, nir.CubaLIF):
             return torch.nn.Identity()
         elif isinstance(m, nir.NIRGraph):
@@ -47,6 +48,8 @@ def _recurrent_model_map(m: nir.NIRNode, device: str = "cpu") -> torch.nn.Module
             )
         else:
             raise NotImplementedError(f"Unsupported module {m}")
+    else:
+        return mapped_model
 
 
 def test_extract_empty():
@@ -150,6 +153,19 @@ def test_execute_recurrent():
     assert torch.allclose(y1[0], y2[0])
     out, s = m(*m(data))
     assert torch.allclose(out, torch.tensor(2.0))
+
+
+def test_execute_graph_in_graph():
+    w = np.ones((1, 1)) * 2
+    g1 = nir.NIRGraph.from_list(nir.Linear(w))
+    g2 = nir.NIRGraph.from_list(g1, nir.Linear(w))
+    m = load(g2, _torch_model_map)
+    data = torch.ones(1, 1)
+    out, state = m(data)
+    assert torch.allclose(out, torch.tensor(4.0))
+    assert torch.allclose(
+        state.state["nirgraph"][0].cache["linear"], torch.tensor([2.0])
+    )
 
 
 def test_import_braille():

--- a/tests/test_graph_executor.py
+++ b/tests/test_graph_executor.py
@@ -1,7 +1,7 @@
 import torch
 
 from nirtorch.graph import TorchGraph
-from nirtorch.graph_executor import GraphExecutor, GraphExecutorState
+from nirtorch.graph_executor import GraphExecutor
 
 
 def test_execute_stateful_then_stateless():
@@ -15,9 +15,9 @@ def test_execute_stateful_then_stateless():
             return x + state, x
 
     s = StatefulModel()
-    l = torch.nn.Linear(1, 1, bias=False)
-    l.weight.data = torch.tensor([[1]]).float()
-    graph = TorchGraph.from_torch_modules({"0": s, "1": l}, [("0", "1")])
+    lin = torch.nn.Linear(1, 1, bias=False)
+    lin.weight.data = torch.tensor([[1]]).float()
+    graph = TorchGraph.from_torch_modules({"0": s, "1": lin}, [("0", "1")])
 
     # With state
     executor = GraphExecutor(graph, True)

--- a/tests/test_graph_executor.py
+++ b/tests/test_graph_executor.py
@@ -1,0 +1,34 @@
+import torch
+
+from nirtorch.graph import TorchGraph
+from nirtorch.graph_executor import GraphExecutor, GraphExecutorState
+
+
+def test_execute_stateful_then_stateless():
+    class StatefulModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, state=None):
+            if state is None:
+                state = 0
+            return x + state, x
+
+    s = StatefulModel()
+    l = torch.nn.Linear(1, 1, bias=False)
+    l.weight.data = torch.tensor([[1]]).float()
+    graph = TorchGraph.from_torch_modules({"0": s, "1": l}, [("0", "1")])
+
+    # With state
+    executor = GraphExecutor(graph, True)
+    data = torch.ones(1, 1)
+    out, state = executor(data)
+    assert torch.allclose(out, torch.ones(1))
+    out, _ = executor(data, state)
+    assert torch.allclose(out, torch.ones(1) * 2)
+
+    # Without state
+    executor = GraphExecutor(graph, False)
+    data = torch.ones(1, 1)
+    out = executor(data)
+    assert torch.allclose(out, torch.ones(1))

--- a/tests/test_to_nir.py
+++ b/tests/test_to_nir.py
@@ -119,9 +119,9 @@ def test_ignore_batch_dim():
         model, extractor, torch.ones(raw_input_shape), ignore_dims=[0]
     )
     exp_input_shape = (3,)
-    assert np.alltrue(g.nodes["input"].input_type["input"] == np.array(exp_input_shape))
+    assert np.all(g.nodes["input"].input_type["input"] == np.array(exp_input_shape))
     assert g.nodes["model"].weight.shape == (1, 3)
-    assert np.alltrue(g.nodes["output"].output_type["output"] == np.array([1]))
+    assert np.all(g.nodes["output"].output_type["output"] == np.array([1]))
 
 
 def test_ignore_time_and_batch_dim():
@@ -135,7 +135,7 @@ def test_ignore_time_and_batch_dim():
         model, extractor, torch.ones(raw_input_shape), ignore_dims=[0, -2]
     )
     exp_input_shape = (3,)
-    assert np.alltrue(g.nodes["input"].input_type["input"] == np.array(exp_input_shape))
+    assert np.all(g.nodes["input"].input_type["input"] == np.array(exp_input_shape))
     assert g.nodes["model"].weight.shape == (1, 3)
 
     raw_input_shape = (1, 10, 3)
@@ -143,7 +143,7 @@ def test_ignore_time_and_batch_dim():
         model, extractor, torch.ones(raw_input_shape), ignore_dims=[0, 1]
     )
     exp_input_shape = (3,)
-    assert np.alltrue(g.nodes["input"].input_type["input"] == np.array(exp_input_shape))
+    assert np.all(g.nodes["input"].input_type["input"] == np.array(exp_input_shape))
 
 
 # def test_extract_stateful():


### PR DESCRIPTION
This PR improves the parsing of subgraphs for Torch graphs by (1) explicitly parsing input nodes in the TorchGraph class and (2) moving some of the pruning of tensor nodes into the Graph tracer to avoid ambiguity.

I also rearrange the code slightly
* Refactored out the GraphExecutor to a separate file with separate tests
* Renamed Graph to TorchGraph and added tests for inputs
* Added specialized functions for processing input nodes and edges
* Updated Nix flakes