### PR TITLE
Ensured fx nodes cannot be named after keywords

### DIFF
--- a/nirtorch/torch_tracer.py
+++ b/nirtorch/torch_tracer.py
@@ -71,7 +71,9 @@ class NIRTorchTransformer(torch.fx.Transformer):
 def torch_to_nir(
     module: torch.nn.Module,
     module_map: Dict[torch.nn.Module, Callable[[torch.nn.Module], nir.NIRNode]],
-    default_dict: Dict[torch.nn.Module, Callable[[torch.nn.Module], nir.NIRNode]] = DEFAULT_MAP,
+    default_dict: Dict[
+        torch.nn.Module, Callable[[torch.nn.Module], nir.NIRNode]
+    ] = DEFAULT_MAP,
 ) -> nir.NIRGraph:
     """
     Traces a PyTorch module and converts it to a NIR graph using the specified module map.


### PR DESCRIPTION
Fixes a bug where nodes like `nir.IF` would be called `if` in the generated Python code, which is *bad*