### PR TITLE
Added code to support recursion

### DIFF
--- a/nirtorch/nir_interpreter.py
+++ b/nirtorch/nir_interpreter.py
@@ -51,6 +51,10 @@ def _default_map_conv2d(conv: nir.Conv2d) -> torch.nn.Conv2d:
     return c
 
 
+def _default_map_flatten(flatten: nir.Flatten) -> torch.nn.Flatten:
+    return torch.nn.Flatten(start_dim=flatten.start_dim, end_dim=flatten.end_dim)
+
+
 def _default_map_linear(linear: nir.Linear) -> torch.nn.Linear:
     module = torch.nn.Linear(
         linear.weight.shape[-1], linear.weight.shape[-2], bias=False
@@ -63,7 +67,7 @@ def _default_map_avgpool2d(pool: nir.AvgPool2d):
 
 def _default_map_sumpool2d(pool: nir.SumPool2d):
     # TODO: Add support for padding
-    return torch.nn.LPPool1d(norm_type=1, kernel_size=pool.kernel_size, stride=pool.stride)
+    return torch.nn.LPPool2d(norm_type=1, kernel_size=pool.kernel_size, stride=pool.stride)
 
 
 DEFAULT_MAP: NodeMapType = {
@@ -74,6 +78,7 @@ DEFAULT_MAP: NodeMapType = {
     nir.AvgPool2d: _default_map_avgpool2d,
     nir.Conv1d: _default_map_conv1d,
     nir.Conv2d: _default_map_conv2d,
+    nir.Flatten: _default_map_flatten,
     nir.Linear: _default_map_linear,
     nir.SumPool2d: _default_map_sumpool2d
 }

--- a/nirtorch/nir_interpreter.py
+++ b/nirtorch/nir_interpreter.py
@@ -58,15 +58,24 @@ def _default_map_linear(linear: nir.Linear) -> torch.nn.Linear:
     module.weight.data = torch.from_numpy(linear.weight)
     return module
 
+def _default_map_avgpool2d(pool: nir.AvgPool2d):
+    return torch.nn.AvgPool2d(kernel_size=pool.kernel_size, stride=pool.stride, padding=pool.padding)
+
+def _default_map_sumpool2d(pool: nir.SumPool2d):
+    # TODO: Add support for padding
+    return torch.nn.LPPool1d(norm_type=1, kernel_size=pool.kernel_size, stride=pool.stride)
+
 
 DEFAULT_MAP: NodeMapType = {
     nir.Input: lambda input: torch.nn.Identity(),
     nir.Output: lambda output: torch.nn.Identity(),
     # Node mappings
     nir.Affine: _default_map_affine,
+    nir.AvgPool2d: _default_map_avgpool2d,
     nir.Conv1d: _default_map_conv1d,
     nir.Conv2d: _default_map_conv2d,
     nir.Linear: _default_map_linear,
+    nir.SumPool2d: _default_map_sumpool2d
 }
 
 

--- a/tests/test_nir_interpreter.py
+++ b/tests/test_nir_interpreter.py
@@ -270,10 +270,8 @@ def test_map_out_of_order():
     assert torch.allclose(module(data)[0], torch.from_numpy(w) @ data)
 
 
-# TODO: Implement recursive calls
-@pytest.mark.skip("Recursion is not implemented yet")
 def test_map_recursive_graph():
-    w = np.random.random((2, 3)).astype(np.float32)
+    w = np.random.random((3, 2)).astype(np.float32)
     nodes = {
         "linear": nir.Linear(w),
         "input": nir.Input(np.array([2])),
@@ -282,8 +280,8 @@ def test_map_recursive_graph():
     edges = [("linear", "linear"), ("input", "linear"), ("linear", "output")]
     graph = nir.NIRGraph(nodes, edges)
     module = nir_interpreter.nir_to_torch(graph, {nir.Linear: _map_linear_node})
-    data = torch.rand(2)
-    assert torch.allclose(module(data), data @ torch.from_numpy(w))
+    data = torch.rand(2) 
+    assert torch.allclose(module(data)[0], data @ torch.from_numpy(w).T)
 
 
 ##########################################

--- a/tests/test_nir_interpreter.py
+++ b/tests/test_nir_interpreter.py
@@ -224,6 +224,17 @@ def test_map_linear_graph_default():
     assert isinstance(out, typing.Tuple)
     assert out[0].shape == (2,)
 
+def test_map_sequential_graph():
+    l1 = nir.Linear(np.random.random((2, 2)))
+    l2 = nir.Linear(np.random.random((2, 2)))
+    l3 = nir.Linear(np.random.random((2, 2)))
+    l4 = nir.Linear(np.random.random((2, 2)))
+    graph = nir.NIRGraph.from_list(l1, l2, l3, l4)
+    module = nir_interpreter.nir_to_torch(graph, {})
+    data = torch.rand(2)
+    expected = torch.from_numpy(l4.weight @ (l3.weight @ (l2.weight @ (l1.weight @ data.numpy())))).float()
+    assert len(list(module.children())) == 4
+    assert torch.allclose(module(data)[0], expected)
 
 def test_map_subgraph_default():
     w = np.random.random((2, 3)).astype(np.float32)

--- a/tests/test_nir_interpreter.py
+++ b/tests/test_nir_interpreter.py
@@ -271,17 +271,21 @@ def test_map_out_of_order():
 
 
 def test_map_recursive_graph():
-    w = np.random.random((3, 2)).astype(np.float32)
+    w = np.random.random((2, 2)).astype(np.float32)
     nodes = {
         "linear": nir.Linear(w),
         "input": nir.Input(np.array([2])),
-        "output": nir.Output(np.array([3])),
+        "output": nir.Output(np.array([2])),
     }
     edges = [("linear", "linear"), ("input", "linear"), ("linear", "output")]
     graph = nir.NIRGraph(nodes, edges)
     module = nir_interpreter.nir_to_torch(graph, {nir.Linear: _map_linear_node})
     data = torch.rand(2) 
-    assert torch.allclose(module(data)[0], data @ torch.from_numpy(w).T)
+    expected = data @ torch.from_numpy(w).T
+    actual, state = module(data)
+    assert torch.allclose(actual, expected)
+    actual2, _ = module(data, state)
+    assert torch.allclose(actual2, (expected + data) @ torch.from_numpy(w).T)
 
 
 ##########################################

--- a/tests/test_nir_interpreter.py
+++ b/tests/test_nir_interpreter.py
@@ -84,18 +84,10 @@ def test_map_nodes_with_periods_in_name():
 def test_map_avg_pool_2d():
     pool = nir.AvgPool2d(2, 1, (1, 2))
     torch_pool = nir_interpreter.nir_to_torch(pool, {})
+    assert isinstance(torch_pool, torch.nn.AvgPool2d)
     assert torch_pool.kernel_size == 2
     assert torch_pool.stride == 1
     assert torch_pool.padding == (1, 2)
-
-
-def test_map_linear_node():
-    w = np.random.random((2, 3)).astype(np.float32)
-    linear = nir.Linear(w)
-    module = nir_interpreter._map_nir_node_to_torch(linear, nir_interpreter.DEFAULT_MAP)
-    assert torch.allclose(module.weight, torch.from_numpy(w))
-    out = module(torch.ones(3))
-    assert out.shape == (2,)
 
 
 def test_map_conv1d_node():
@@ -169,6 +161,21 @@ def test_map_if_node():
     assert isinstance(torch_if.get_submodule("nir_node_if"), MyIF)
 
 
+def test_map_flatten():
+    flatten = nir.Flatten({"input": np.array([1, 2, 10, 10])}, 2, 3)
+    torch_flatten = nir_interpreter.nir_to_torch(flatten, {})
+    assert isinstance(torch_flatten, torch.nn.Flatten)
+    assert torch_flatten.start_dim == 2
+    assert torch_flatten.end_dim == 3
+
+def test_map_linear_node():
+    w = np.random.random((2, 3)).astype(np.float32)
+    linear = nir.Linear(w)
+    module = nir_interpreter._map_nir_node_to_torch(linear, nir_interpreter.DEFAULT_MAP)
+    assert torch.allclose(module.weight, torch.from_numpy(w))
+    out = module(torch.ones(3))
+    assert out.shape == (2,)
+
 def test_map_single_node():
     w = np.random.random((2, 2))
     node = nir.Linear(w)
@@ -179,6 +186,7 @@ def test_map_single_node():
 def test_map_sum_pool_2d():
     pool = nir.SumPool2d(2, 1, 0)
     torch_pool = nir_interpreter.nir_to_torch(pool, {})
+    assert isinstance(torch_pool, torch.nn.LPPool2d)
     assert torch_pool.norm_type == 1
     assert torch_pool.kernel_size == 2
     assert torch_pool.stride == 1

--- a/tests/test_nir_interpreter.py
+++ b/tests/test_nir_interpreter.py
@@ -81,6 +81,14 @@ def test_map_nodes_with_periods_in_name():
     assert named_children[0][0] == "some_name"
 
 
+def test_map_avg_pool_2d():
+    pool = nir.AvgPool2d(2, 1, (1, 2))
+    torch_pool = nir_interpreter.nir_to_torch(pool, {})
+    assert torch_pool.kernel_size == 2
+    assert torch_pool.stride == 1
+    assert torch_pool.padding == (1, 2)
+
+
 def test_map_linear_node():
     w = np.random.random((2, 3)).astype(np.float32)
     linear = nir.Linear(w)
@@ -166,6 +174,14 @@ def test_map_single_node():
     node = nir.Linear(w)
     torch_linear = nir_interpreter.nir_to_torch(node, {})
     assert torch.allclose(torch_linear.weight, torch.from_numpy(w))
+
+
+def test_map_sum_pool_2d():
+    pool = nir.SumPool2d(2, 1, 0)
+    torch_pool = nir_interpreter.nir_to_torch(pool, {})
+    assert torch_pool.norm_type == 1
+    assert torch_pool.kernel_size == 2
+    assert torch_pool.stride == 1
 
 
 def test_fails_on_graphs_without_input_output():


### PR DESCRIPTION
Adds support for recursion in modules by 

1. Saving the output of a recursive module in the state
2. Re-using the previous output from the state, defaulting to `torch.zeros(1)`.