### PR TITLE
Fix: NIRGraph error by disabling type checks

### DIFF
--- a/nirtorch/from_nir.py
+++ b/nirtorch/from_nir.py
@@ -54,7 +54,7 @@ def load(
     return_state: bool = True,
 ) -> nn.Module:
     """
-    DEPRECATED: Use `nirtorch.torch_to_nir` instead.
+    DEPRECATED: Use `nirtorch.nir_to_torch` instead.
 
     Load a NIR graph and convert it to a torch module using the given model map.
 

--- a/nirtorch/from_nir.py
+++ b/nirtorch/from_nir.py
@@ -41,7 +41,7 @@ def _map_graph_to_torch(
         (sanitize_name(src), sanitize_name(dst)) for src, dst in nir_graph.edges
     ]
     # Reconstruct NIR graph with torch modules
-    recon_graph = nir.NIRGraph(nodes, sanitized_edges)
+    recon_graph = nir.NIRGraph(nodes, sanitized_edges, type_check=False)
     # Build a TorchGraph for tracing and executing
     trace_graph = TorchGraph.from_torch_modules(recon_graph.nodes, recon_graph.edges)
     # Build and return a graph executor module

--- a/nirtorch/to_nir.py
+++ b/nirtorch/to_nir.py
@@ -160,4 +160,4 @@ def extract_nir_graph(
             logging.warn(f"removing self-connection {edge}")
             nir_edges.remove(edge)
 
-    return nir.NIRGraph(nir_nodes, nir_edges)
+    return nir.NIRGraph(nir_nodes, nir_edges, type_check=False)

--- a/nirtorch/torch_tracer.py
+++ b/nirtorch/torch_tracer.py
@@ -159,12 +159,12 @@ def torch_to_nir(
         # Add Node
         if node.op == "placeholder":
             if node.target == "input" or node.prev.op == "root":
-                nodes[str(node.name)] = nir.Input(np.array([1]))
+                nodes[str(node.name)] = nir.Input(np.array([1]))  # FIXME: Use correct shape
             else:
                 ignored_nodes.add(node)
                 continue
         elif node.op == "output":
-            nodes[str(node.name)] = nir.Output(np.array([1]))
+            nodes[str(node.name)] = nir.Output(np.array([1]))  # FIXME: Use correct shape
         elif node.op == "call_function":
             # Ensure that we bypass add nodes
             # TODO: Consider using transformations for this

--- a/tests/test_nir_interpreter.py
+++ b/tests/test_nir_interpreter.py
@@ -257,7 +257,7 @@ def test_can_overwrite_default_map():
 
 
 def test_map_out_of_order():
-    w = np.random.random((2, 3)).astype(np.float32)
+    w = np.random.random((3, 2)).astype(np.float32)
     nodes = {
         "linear": nir.Linear(w),
         "input": nir.Input(np.array([2])),
@@ -266,7 +266,7 @@ def test_map_out_of_order():
     edges = [("input", "linear"), ("linear", "output")]
     graph = nir.NIRGraph(nodes, edges)
     module = nir_interpreter.nir_to_torch(graph, {nir.Linear: _map_linear_node})
-    data = torch.rand(3)
+    data = torch.rand(2)
     assert torch.allclose(module(data)[0], torch.from_numpy(w) @ data)
 
 

--- a/tests/test_to_nir.py
+++ b/tests/test_to_nir.py
@@ -38,7 +38,10 @@ def test_extract_nir_edges():
     sample_data = torch.rand(1, 2, 16, 16)
 
     def dummy_model_map(module: nn.Module) -> nir.NIRNode:
-        return nir.NIRNode()
+        return nir.LI(tau=np.array([1.0]),
+                      r=np.array([1.0]),
+                      v_leak=np.array([0.0]))
+            
 
     nir_graph = extract_nir_graph(mymodel, dummy_model_map, sample_data, "mysequential")
 

--- a/tests/test_torch_tracer.py
+++ b/tests/test_torch_tracer.py
@@ -101,7 +101,7 @@ def test_trace_addition():
 
 
 def test_trace_sequential():
-    model = torch.nn.Sequential(torch.nn.Linear(2, 1), torch.nn.Linear(1, 1))
+    model = torch.nn.Sequential(torch.nn.Linear(1, 2), torch.nn.Linear(2, 1))
     graph = torch_to_nir(model, {})
     assert graph.__class__ == nir.NIRGraph
     assert len(graph.nodes) == 4


### PR DESCRIPTION
This fixes the issue #35, originally adressed in a NIR [issue](https://github.com/neuromorphs/NIR/issues/135)