### PR TITLE
Set Input and NIRGraph input_type based on first nodes in graph

### DIFF
--- a/nirtorch/torch_tracer.py
+++ b/nirtorch/torch_tracer.py
@@ -159,12 +159,12 @@ def torch_to_nir(
         # Add Node
         if node.op == "placeholder":
             if node.target == "input" or node.prev.op == "root":
-                nodes[str(node.name)] = nir.Input(np.array([1]))  # FIXME: Use correct shape
+                nodes[str(node.name)] = nir.Input(input_type=None)
             else:
                 ignored_nodes.add(node)
                 continue
         elif node.op == "output":
-            nodes[str(node.name)] = nir.Output(np.array([1]))  # FIXME: Use correct shape
+            nodes[str(node.name)] = nir.Output(output_type=None)
         elif node.op == "call_function":
             # Ensure that we bypass add nodes
             # TODO: Consider using transformations for this
@@ -217,8 +217,44 @@ def torch_to_nir(
             # Otherwise, add an edge
             elif in_node not in ignored_nodes:
                 edges.append((in_node.name, node.name))
+
+    # Update input_type for all Input nodes based on the follower nodes' input_type.
+    # The Input.input_type has been set to a placeholder value (np.array([1])) in the code above.
+    for node_name, node in nodes.items():
+        if isinstance(node, nir.Input):
+            follower_edges = [edge for edge in edges if edge[0] == node_name]
+            follower_nodes = [nodes[edge[1]] for edge in follower_edges]
+
+            # Check that all follower nodes have the same input_type
+            first_input_type = None
+            for follower_node in follower_nodes:
+                if first_input_type is None:
+                    first_input_type = follower_node.input_type
+                else:
+                    # Verify they match (code taken from to NIRGraph._check_types)
+                    if len(first_input_type) != len(follower_node.input_type):
+                        raise ValueError(
+                            f"Input type length mismatch for followers of {node_name}"
+                        )
+
+                    if len(first_input_type.keys()) == 1:
+                        first_type = list(first_input_type.values())[0]
+                        follower_type = list(follower_node.input_type.values())[0]
+                        if not np.array_equal(first_type, follower_type):
+                            raise ValueError(
+                                f"Input type mismatch for followers of {node_name}: {first_type} vs {follower_type}"
+                            )
+                    else:
+                        raise NotImplementedError(
+                            "Multiple input/output types not supported yet"
+                        )
+
+            # Update the input node's input_type if we found a valid type
+            if first_input_type is not None:
+                node.input_type = first_input_type
+                node.output_type = first_input_type
+
     graph = nir.NIRGraph(nodes=nodes, edges=edges)
-    graph.infer_types()
     return graph
 
 

--- a/tests/test_torch_tracer.py
+++ b/tests/test_torch_tracer.py
@@ -52,7 +52,7 @@ def test_trace_mapped_module_stateless():
     class MyModule(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.lin = torch.nn.Linear(1, 1)
+            self.lin = torch.nn.Linear(3, 2)
 
         def forward(self, x, state):
             return self.lin(x) + state
@@ -63,13 +63,16 @@ def test_trace_mapped_module_stateless():
     assert len(graph.edges) == 2
     assert len(_filter_edges(graph, nir.Input, nir.Affine)) == 1
     assert len(_filter_edges(graph, nir.Affine, nir.Output)) == 1
+    input_node_name, input_node = list(graph.inputs.items())[0]
+    assert input_node.input_type["input"] == np.array([3])
+    assert graph.input_type[input_node_name] == np.array([3])
 
 
 def test_trace_mapped_module_stateful():
     class MyModule(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.lin = torch.nn.Linear(1, 1)
+            self.lin = torch.nn.Linear(3, 2)
             self.state = torch.tensor([1.0])
 
         def forward(self, x):
@@ -81,6 +84,9 @@ def test_trace_mapped_module_stateful():
     assert len(graph.edges) == 2
     assert len(_filter_edges(graph, nir.Input, nir.Affine)) == 1
     assert len(_filter_edges(graph, nir.Affine, nir.Output)) == 1
+    input_node_name, input_node = list(graph.inputs.items())[0]
+    assert input_node.input_type["input"] == np.array([3])
+    assert graph.input_type[input_node_name] == np.array([3])
 
 
 def test_trace_addition():


### PR DESCRIPTION
This PR replaces #38.

For the new type inference in NIR  (https://github.com/neuromorphs/NIR/pull/153) to work, we need valid types in the Input nodes. This is what this PR does.

We initialize both Input and Output types to None, then use the code in this PR to update them in Input after we constructed the graph, and finally let the type inference in NIR update the Output type.

This PR currently targets the nir-update branch, because the changes there are needed to make this work.
This also means all the checks will probably fail, because our CI uses the published NIR version.