### PR TITLE
map torch.nn.Linear without bias as nir.Linear

### DIFF
--- a/nirtorch/torch_tracer.py
+++ b/nirtorch/torch_tracer.py
@@ -7,12 +7,15 @@ import nir
 import torch
 
 
+def _map_linear(module: torch.nn.Module) -> nir.NIRNode:
+    if module.bias is None:
+        return nir.Linear(module.weight.detach().numpy())
+    else:
+        return nir.Affine(module.weight.detach().numpy(), module.bias.detach().numpy())
+
+
 DEFAULT_MAP: Dict[torch.nn.Module, Callable[[torch.nn.Module], nir.NIRNode]] = {
-    torch.nn.Linear: (
-        lambda module: nir.Affine(
-            module.weight.detach().numpy(), module.bias.detach().numpy()
-        )
-    )
+    torch.nn.Linear: _map_linear
     # TODO: Add more default nodes
     # https://github.com/neuromorphs/NIRTorch/issues/25
 }

--- a/tests/test_torch_tracer.py
+++ b/tests/test_torch_tracer.py
@@ -35,6 +35,12 @@ def test_trace_default_linear():
     assert graph.__class__ == nir.Affine
 
 
+def test_trace_default_linear_no_bias():
+    model = torch.nn.Linear(1, 1, bias=False)
+    graph = torch_to_nir(model, {})
+    assert graph.__class__ == nir.Linear
+
+
 def test_trace_mapped_module():
     class MyModule(torch.nn.Module):
         def forward(self, x):


### PR DESCRIPTION
Otherwise we get an NoneTypeError when trying to access `bias`