### PR TITLE
ci: temporary workaround for sinabs dependency issue

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -2,3 +2,4 @@ pytest
 torch
 ruff
 git+https://github.com/synsense/sinabs
+matplotlib # Temporary dependency until https://github.com/synsense/sinabs/issues/302 is fixed


### PR DESCRIPTION
Sinabs from GitHub currently depends on matplotlib, but hasn't added it to the dependencies.
Bug report: https://github.com/synsense/sinabs/issues/302

I am adding matplotlib to test requirements temporarily to fix the CI.