### PR TITLE
Added option to bypass getitem traces in stateful modules

### DIFF
--- a/nirtorch/torch_tracer.py
+++ b/nirtorch/torch_tracer.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Set, Tuple
+from typing import Any, Callable, Dict, Optional, Set, Tuple, Type
 import operator
 
 import numpy as np
@@ -78,6 +78,8 @@ def torch_to_nir(
         torch.nn.Module, Callable[[torch.nn.Module], nir.NIRNode]
     ] = DEFAULT_MAP,
     type_check: bool = True,
+    stateful_modules: Optional[Set[Type[torch.nn.Module]]] = None,
+    concrete_args: Optional[Dict[str, Any]] = None,
 ) -> nir.NIRGraph:
     """
     Traces a PyTorch module and converts it to a NIR graph using the specified module map.
@@ -106,6 +108,13 @@ def torch_to_nir(
             of default mappings that, by default, maps trivial modules like torch.nn.Linear. Override
             the dictionary to provide custom mappings.
         type_check (bool): Whether to run type checking on generated NIRGraphs
+        stateful_modules (Optional[Set[Type[torch.nn.Module]]]): A set of module types that return
+            (output, state) tuples. When these modules are encountered, getitem operations extracting
+            index 0 (output) will be treated as signal flow, while index 1 (state) will be ignored.
+            This enables tracing through modules with stateful return signatures.
+        concrete_args (Optional[Dict[str, Any]]): A dictionary of concrete values for function arguments
+            during tracing. For example, {'state': None} will treat the 'state' argument as the concrete
+            value None rather than a symbolic Proxy, which can help with tracing stateful modules.
     """
     # Merge the default dictionary, if it exists
     if default_dict is not None:
@@ -117,7 +126,7 @@ def torch_to_nir(
 
     # Trace the graph
     tracer = NIRTorchTracer(module_map.keys())
-    traced = tracer.trace(module)
+    traced = tracer.trace(module, concrete_args=concrete_args)
 
     if len(traced.nodes) == 2 and len(list(tracer.root.children())) == 0:
         raise ValueError(
@@ -176,6 +185,32 @@ def torch_to_nir(
             #       https://pytorch.org/docs/stable/fx.html#torch.fx.Transformer
             if node.target == operator.add:
                 bypass_nodes.add(node)
+            # Ignore assertion functions inserted by torch.fx for concrete_args validation
+            elif getattr(node.target, "__name__", "") == "_assert_is_none":
+                ignored_nodes.add(node)
+            # Handle getitem for stateful modules that return (output, state) tuples
+            elif node.target == operator.getitem:
+                source_node = node.args[0]
+                index = node.args[1]
+                # Check if this getitem is extracting from a stateful module's output
+                if (
+                    stateful_modules
+                    and source_node.op == "call_module"
+                ):
+                    torch_module = graph_module.get_submodule(source_node.target)
+                    if type(torch_module) in stateful_modules:
+                        if index == 0:
+                            # Index 0 is the output tensor - bypass to follow signal flow
+                            bypass_nodes.add(node)
+                        else:
+                            # Index 1+ is state - ignore it
+                            ignored_nodes.add(node)
+                        continue
+                # If not a stateful module getitem, raise an error
+                raise ValueError(
+                    "getitem is only supported for stateful modules specified in stateful_modules. "
+                    "Please modify your model or add the module type to stateful_modules."
+                )
             # Raise a warning if we encounter other methods than addition
             else:
                 raise ValueError(

--- a/tests/test_torch_tracer.py
+++ b/tests/test_torch_tracer.py
@@ -199,3 +199,126 @@ def test_recursive_stateful():
     model = MyModule()
     graph = torch_to_nir(model, {})
     assert graph.__class__ == nir.NIRGraph
+
+
+def test_stateful_module_with_tuple_return():
+    """Test tracing a module that returns (output, state) tuples."""
+
+    class StatefulCell(torch.nn.Module):
+        """A simple stateful module that returns (output, state) tuple."""
+
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 2)
+
+        def forward(self, x, state=None):
+            if state is None:
+                state = torch.zeros(2)
+            output = self.linear(x) + state
+            new_state = output.detach()
+            return output, new_state
+
+    def map_stateful_cell(module):
+        return nir.Affine(
+            module.linear.weight.detach().numpy(),
+            module.linear.bias.detach().numpy(),
+        )
+
+    model = StatefulCell()
+    graph = torch_to_nir(
+        model,
+        {StatefulCell: map_stateful_cell},
+        stateful_modules={StatefulCell},
+    )
+    assert graph.__class__ == nir.Affine
+
+
+def test_sequential_with_stateful_modules():
+    """Test tracing a sequential model containing stateful modules."""
+
+    class StatefulCell(torch.nn.Module):
+        """A simple stateful module that returns (output, state) tuple."""
+
+        def __init__(self, in_features, out_features):
+            super().__init__()
+            self.linear = torch.nn.Linear(in_features, out_features)
+
+        def forward(self, x, state=None):
+            if state is None:
+                state = torch.zeros(self.linear.out_features)
+            output = self.linear(x) + state
+            new_state = output.detach()
+            return output, new_state
+
+    class SequentialStateful(torch.nn.Module):
+        """A sequential module that handles stateful children."""
+
+        def __init__(self, *modules):
+            super().__init__()
+            self.layers = torch.nn.ModuleList(modules)
+            self.stateful = [isinstance(m, StatefulCell) for m in modules]
+
+        def forward(self, x, state=None):
+            if state is None:
+                state = [None] * len(self.layers)
+            output_states = []
+            for i, layer in enumerate(self.layers):
+                if self.stateful[i]:
+                    x, s = layer(x, state[i])
+                    output_states.append(s)
+                else:
+                    x = layer(x)
+                    output_states.append(None)
+            return x, output_states
+
+    def map_stateful_cell(module):
+        return nir.Affine(
+            module.linear.weight.detach().numpy(),
+            module.linear.bias.detach().numpy(),
+        )
+
+    model = SequentialStateful(
+        StatefulCell(3, 4),
+        torch.nn.Linear(4, 2),
+    )
+
+    graph = torch_to_nir(
+        model,
+        {StatefulCell: map_stateful_cell},
+        stateful_modules={StatefulCell},
+        concrete_args={"state": None},
+    )
+
+    assert graph.__class__ == nir.NIRGraph
+    assert len(graph.nodes) == 4  # input, StatefulCell, Linear, output
+    assert len(graph.edges) == 3
+    assert len(_filter_nodes(graph, nir.Input)) == 1
+    assert len(_filter_nodes(graph, nir.Output)) == 1
+    assert len(_filter_nodes(graph, nir.Affine)) == 2
+    assert len(_filter_edges(graph, nir.Input, nir.Affine)) == 1
+    assert len(_filter_edges(graph, nir.Affine, nir.Affine)) == 1
+    assert len(_filter_edges(graph, nir.Affine, nir.Output)) == 1
+
+
+def test_concrete_args_state_none():
+    """Test that concrete_args={'state': None} allows tracing with state parameter."""
+
+    class ModuleWithState(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 2)
+
+        def forward(self, x, state=None):
+            # When state is None (concrete), this creates a real list, not a Proxy
+            if state is None:
+                state = [0.0]
+            return self.linear(x)
+
+    model = ModuleWithState()
+    graph = torch_to_nir(
+        model,
+        {},
+        concrete_args={"state": None},
+    )
+    assert graph.__class__ == nir.NIRGraph
+    assert len(_filter_nodes(graph, nir.Affine)) == 1


### PR DESCRIPTION
- Fixed tracing for stateful modules that return a tuple of (values, state) by ignoring the state nodes
- Added options to list stateful modules when tracing them, so libraries to explicitly inform the tracing when to ignore state
- Added `concrete_args` for tracing hints