### PR TITLE
Add support for bypassing selected modules during tracing

### DIFF
--- a/nirtorch/torch_tracer.py
+++ b/nirtorch/torch_tracer.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable, Dict, Optional, Set, Tuple, Type
 import operator
+import logging
 
 import numpy as np
 
@@ -79,6 +80,7 @@ def torch_to_nir(
     ] = DEFAULT_MAP,
     type_check: bool = True,
     stateful_modules: Optional[Set[Type[torch.nn.Module]]] = None,
+    bypass_modules: Optional[Set[Type[torch.nn.Module]]] = None,
     concrete_args: Optional[Dict[str, Any]] = None,
 ) -> nir.NIRGraph:
     """
@@ -112,6 +114,9 @@ def torch_to_nir(
             (output, state) tuples. When these modules are encountered, getitem operations extracting
             index 0 (output) will be treated as signal flow, while index 1 (state) will be ignored.
             This enables tracing through modules with stateful return signatures.
+        bypass_modules (Optional[Set[Type[torch.nn.Module]]]): A set of module types that are supposed
+            to be bypassed during tracing. When any module contained in this set is encountered,
+            its predecessor nodes will directly be connected to its successor nodes.
         concrete_args (Optional[Dict[str, Any]]): A dictionary of concrete values for function arguments
             during tracing. For example, {'state': None} will treat the 'state' argument as the concrete
             value None rather than a symbolic Proxy, which can help with tracing stateful modules.
@@ -226,8 +231,17 @@ def torch_to_nir(
                 )
         elif node.op == "call_module":
             torch_module = graph_module.get_submodule(node.target)
-            nir_module = module_map[torch_module.__class__](torch_module)
-            nodes[str(node.name)] = nir_module
+            if torch_module.__class__ in module_map:
+                nir_module = module_map[torch_module.__class__](torch_module)
+                nodes[str(node.name)] = nir_module
+            elif bypass_modules is not None and torch_module.__class__ in bypass_modules:
+                    bypass_nodes.add(node)
+                    logging.info(f"Bypassing node: {torch_module.__class__}.")
+            else:
+                raise ValueError(
+                    f"Unknown module encountered: {torch_module.__class__}. "
+                    "Consider adding its type to the 'bypass_modules' set."
+                )
         elif node.op == "get_attr":
             # Bypass attribute
             bypass_nodes.add(node)

--- a/nirtorch/torch_tracer.py
+++ b/nirtorch/torch_tracer.py
@@ -1,6 +1,5 @@
 from typing import Any, Callable, Dict, Optional, Set, Tuple, Type
 import operator
-import logging
 
 import numpy as np
 
@@ -74,13 +73,12 @@ class NIRTorchTransformer(torch.fx.Transformer):
 
 def torch_to_nir(
     module: torch.nn.Module,
-    module_map: Dict[torch.nn.Module, Callable[[torch.nn.Module], nir.NIRNode]],
+    module_map: Dict[torch.nn.Module, Callable[[torch.nn.Module], Optional[nir.NIRNode]]],
     default_dict: Dict[
         torch.nn.Module, Callable[[torch.nn.Module], nir.NIRNode]
     ] = DEFAULT_MAP,
     type_check: bool = True,
     stateful_modules: Optional[Set[Type[torch.nn.Module]]] = None,
-    bypass_modules: Optional[Set[Type[torch.nn.Module]]] = None,
     concrete_args: Optional[Dict[str, Any]] = None,
 ) -> nir.NIRGraph:
     """
@@ -104,8 +102,10 @@ def torch_to_nir(
 
     Args:
         module (torch.nn.Module): The module of interest
-        module_map (Dict[torch.nn.Module, Callable[[torch.nn.Module], nir.NIRNode]]): A dictionary that maps
-            a given module type to a function that can convert the model to an NIRNode type
+        module_map (Dict[torch.nn.Module, Callable[[torch.nn.Module], Optional[nir.NIRNode]]]):
+            A dictionary that maps a given module type to a function that can convert the model
+            to an NIRNode type. If the return value of the function is None, the node will instead
+            be bypassed, and its predecessor nodes will directly be connected to its successor nodes.
         default_dict (Dict[torch.nn.Module, Callable[[torch.nn.Module], nir.NIRNode]]): An dictionary
             of default mappings that, by default, maps trivial modules like torch.nn.Linear. Override
             the dictionary to provide custom mappings.
@@ -114,9 +114,6 @@ def torch_to_nir(
             (output, state) tuples. When these modules are encountered, getitem operations extracting
             index 0 (output) will be treated as signal flow, while index 1 (state) will be ignored.
             This enables tracing through modules with stateful return signatures.
-        bypass_modules (Optional[Set[Type[torch.nn.Module]]]): A set of module types that are supposed
-            to be bypassed during tracing. When any module contained in this set is encountered,
-            its predecessor nodes will directly be connected to its successor nodes.
         concrete_args (Optional[Dict[str, Any]]): A dictionary of concrete values for function arguments
             during tracing. For example, {'state': None} will treat the 'state' argument as the concrete
             value None rather than a symbolic Proxy, which can help with tracing stateful modules.
@@ -233,14 +230,15 @@ def torch_to_nir(
             torch_module = graph_module.get_submodule(node.target)
             if torch_module.__class__ in module_map:
                 nir_module = module_map[torch_module.__class__](torch_module)
-                nodes[str(node.name)] = nir_module
-            elif bypass_modules is not None and torch_module.__class__ in bypass_modules:
+                # Mapping to None bypasses the node
+                if nir_module is not None:
+                    nodes[str(node.name)] = nir_module
+                else:
                     bypass_nodes.add(node)
-                    logging.info(f"Bypassing node: {torch_module.__class__}.")
             else:
                 raise ValueError(
                     f"Unknown module encountered: {torch_module.__class__}. "
-                    "Consider adding its type to the 'bypass_modules' set."
+                    f"To bypass it, map '{torch_module.__class__.__name__}: None' through the 'module_map'."
                 )
         elif node.op == "get_attr":
             # Bypass attribute

--- a/tests/test_torch_tracer.py
+++ b/tests/test_torch_tracer.py
@@ -322,3 +322,26 @@ def test_concrete_args_state_none():
     )
     assert graph.__class__ == nir.NIRGraph
     assert len(_filter_nodes(graph, nir.Affine)) == 1
+
+
+def test_unknown_module_error():
+    """Test that unknown modules (not contained in 'module_map') raise error by default."""
+    model = torch.nn.Sequential(torch.nn.Linear(1, 2), torch.nn.Dropout(), torch.nn.Linear(2, 1))
+    with pytest.raises(ValueError):
+        torch_to_nir(model, {})
+
+
+def test_unknown_module_bypass():
+    """Test bypassing of unknown modules (not contained in 'module_map')."""
+    model = torch.nn.Sequential(torch.nn.Linear(1, 2), torch.nn.Dropout(), torch.nn.Linear(2, 1))
+    graph = torch_to_nir(model, {}, bypass_modules={torch.nn.Dropout})
+
+    assert graph.__class__ == nir.NIRGraph
+    assert len(graph.nodes) == 4  # input, Linear, Linear, output
+    assert len(graph.edges) == 3
+    assert len(_filter_nodes(graph, nir.Input)) == 1
+    assert len(_filter_nodes(graph, nir.Output)) == 1
+    assert len(_filter_nodes(graph, nir.Affine)) == 2
+    assert len(_filter_edges(graph, nir.Input, nir.Affine)) == 1
+    assert len(_filter_edges(graph, nir.Affine, nir.Affine)) == 1
+    assert len(_filter_edges(graph, nir.Affine, nir.Output)) == 1

--- a/tests/test_torch_tracer.py
+++ b/tests/test_torch_tracer.py
@@ -333,8 +333,11 @@ def test_unknown_module_error():
 
 def test_unknown_module_bypass():
     """Test bypassing of unknown modules (not contained in 'module_map')."""
+    def map_none(_):
+        return None
+
     model = torch.nn.Sequential(torch.nn.Linear(1, 2), torch.nn.Dropout(), torch.nn.Linear(2, 1))
-    graph = torch_to_nir(model, {}, bypass_modules={torch.nn.Dropout})
+    graph = torch_to_nir(model, {torch.nn.Dropout: map_none})
 
     assert graph.__class__ == nir.NIRGraph
     assert len(graph.nodes) == 4  # input, Linear, Linear, output


### PR DESCRIPTION
When tracing a `torch.nn.Module` using the `torch_to_nir` functionality, modules not contained in the `module_map` dictionary result in a `KeyError`:
```
KeyError: <class 'torch.nn.modules.dropout.Dropout'>
```
This pull request adds a parameter to the `torch_to_nir` function that allows for specifying module types that should be bypassed during tracing. This applies to "no-op" modules like `torch.nn.Dropout` or `torch.nn.Identity`, where no NIR primitive equivalent is applicable and the dataflow should simply skip the respective node.

Changes made:
* Added `bypass_modules` parameter (optional set of `torch.nn.Module` subtypes) that will get bypassed during tracing
* More informative error message if encountered module has no valid mapping and is not contained in `bypass_modules`
* Tests to verify correct functionality of the changes made