### PR TITLE
feat: Add NIRData conversion functionalities

### DIFF
--- a/nirtorch/__init__.py
+++ b/nirtorch/__init__.py
@@ -12,6 +12,8 @@ from .from_nir import load  # noqa F401
 from .to_nir import extract_nir_graph
 from .nir_interpreter import nir_to_torch
 from .torch_tracer import torch_to_nir
+from .from_nir_data import from_nir_data
+from .to_nir_data import to_nir_data
 
 __all__ = [
     "extract_nir_graph",
@@ -19,4 +21,6 @@ __all__ = [
     "load",
     "nir_to_torch",
     "torch_to_nir",
+    "from_nir_data",
+    "to_nir_data",
 ]

--- a/nirtorch/from_nir_data.py
+++ b/nirtorch/from_nir_data.py
@@ -1,0 +1,67 @@
+"""
+Convert NIRGraphData to a torch-compatible spike representation.
+"""
+
+import torch
+from nir.data_ir import EventData, NIRGraphData, NIRNodeData
+
+
+def from_nir_data(
+    nir_graph_data: NIRGraphData,
+    dt: float,
+    dynamic_before_transition: bool = True,
+    shape: tuple = ("T", "B", "N"),
+    time_unit: float = 1.0,
+) -> dict:
+    """
+    Args:
+        nir_graph_data: A NIRGraphData object containing the spike data.
+        dt: The time step size of the spike data.
+        dynamic_before_transition: bool, optional
+            If True, it is assumed that the framework evolves the state (e.g.,
+            membrane potential) of the neurons before checking if the threshold
+            has been crossed and generating an event (transition). If False,
+            the state is updated after the event generation.
+        shape: The desired shape of the output spike tensors. Defaults to
+            ('T', 'B', 'N') for (time, batch, neurons).
+            If the output spike tensors should have a different shape, this can
+            be used to specify the correct ordering of dimensions.
+        time_unit: The unit of time for the spike data and dt. Defaults to 1.0,
+            which corresponds to seconds. For milliseconds, set this to 1e-3.
+    Returns:
+        A dictionary mapping node names to spike tensors.
+    """
+    nirdata_shape = ("B", "T", "N")
+    torch_dict = {}
+
+    for node_key, nir_node_data in nir_graph_data.nodes.items():
+        if isinstance(nir_node_data, NIRNodeData):
+            for observable, data in nir_node_data.observables.items():
+                if observable == "spikes":
+                    if isinstance(data, EventData):
+                        data = data.to_time_gridded(
+                            dt=dt * time_unit,
+                            dynamic_before_transition=dynamic_before_transition
+                        )
+                    else:
+                        if data.dynamic_before_transition != dynamic_before_transition:
+                            data = data.toggle_dynamic_before_transition()
+                    torch_spikes = torch.tensor(data.data)
+                    # reorder dimensions to shape specified by `shape` argument
+                    torch_spikes = torch_spikes.permute(
+                        nirdata_shape.index(shape[0]),
+                        nirdata_shape.index(shape[1]),
+                        nirdata_shape.index(shape[2]),
+                    )
+                else:
+                    raise NotImplementedError(
+                        "Only spikes are supported as observables yet."
+                    )
+        else:
+            raise NotImplementedError(
+                "The translation of nested NIRGraphData is not supported."
+            )
+
+        torch_dict[node_key] = torch_spikes.float()
+
+    return torch_dict

--- a/nirtorch/to_nir_data.py
+++ b/nirtorch/to_nir_data.py
@@ -1,0 +1,44 @@
+"""
+Convert spikes from a torch tensor to a NIRGraphData object.
+"""
+
+import torch
+from nir.data_ir import NIRGraphData, NIRNodeData, TimeGriddedData
+
+
+def to_nir_data(
+    torch_dict: dict,
+    dt: float,
+    time_unit: float = 1.0,
+    shape: tuple = ("T", "B", "N"),
+) -> NIRGraphData:
+    """
+    Args:
+        torch_dict: A dictionary mapping node names to spike tensors. If the
+            shape is not (n_time_steps, batch_size, n_neurons), the `shape`
+            argument can be used to specify the correct ordering of dimensions.
+        dt: The time step size of the spike data.
+        time_unit: The unit of time for the spike data and dt. Defaults to 1.0,
+            which corresponds to seconds. For milliseconds, set this to 1e-3.
+        shape: The shape of the input spike tensors. Defaults to
+            ('T', 'B', 'N') for (time, batch, neurons). If the spike tensors
+            have a different shape, this can be used to specify the correct
+            ordering of dimensions.
+    Returns:
+        A NIRGraphData object containing the spike data.
+    """
+    nir_nodes = {}
+
+    for key, spikes in torch_dict.items():
+        # reorder dimensions to (batch, time, neurons)
+        spikes = torch.permute(
+            spikes, (shape.index("B"), shape.index("T"), shape.index("N"))
+        )
+
+        spikes = spikes.detach().cpu().numpy().astype(bool)
+
+        nir_node_data = NIRNodeData({"spikes": TimeGriddedData(spikes, dt * time_unit)})
+        nir_nodes[key] = nir_node_data
+
+    nir_data = NIRGraphData(nir_nodes)
+    return nir_data

--- a/tests/test_nir_data.py
+++ b/tests/test_nir_data.py
@@ -1,0 +1,51 @@
+import nir
+from nirtorch import from_nir_data, to_nir_data
+import numpy as np
+import torch
+
+
+
+def test_event_data_from_nir():
+    nir_data = nir.NIRGraphData(
+        nodes={
+            "lif": nir.NIRNodeData(
+                observables={
+                    "spikes": nir.EventData(
+                        idx=np.random.randint(0, 10, (3, 5)),
+                        time=np.random.rand(3, 5) * 0.1,
+                        n_neurons=10,
+                        t_max=0.1,
+                    )
+                }
+            )
+        }
+    )
+
+    torch_dict = from_nir_data(nir_data, dt=0.001)
+
+    assert "lif" in torch_dict, "Node 'lif' not found in the converted dictionary"
+    assert torch_dict["lif"].shape == (100, 3, 10), (
+        f"Expected shape (100, 3, 10) for node 'lif', but got {torch_dict['lif'].shape}"
+    )
+
+
+def test_stable_conversion():
+    original_spikes = {"lif": torch.randint(0, 2, (4, 10, 10), dtype=torch.float32)}
+
+    nir_data = to_nir_data(original_spikes, dt=0.001)
+    converted_spikes = from_nir_data(nir_data, dt=0.001)
+
+    assert torch.equal(original_spikes["lif"], converted_spikes["lif"]), (
+        "Mismatch in spikes for node 'lif'"
+    )
+
+
+def test_stable_conversion_with_time_unit():
+    original_spikes = {"lif": torch.randint(0, 2, (4, 10, 10), dtype=torch.float32)}
+
+    nir_data = to_nir_data(original_spikes, dt=1e-3, time_unit=1e-3)
+    converted_spikes = from_nir_data(nir_data, dt=1e-3, time_unit=1e-3)
+
+    assert torch.equal(original_spikes["lif"], converted_spikes["lif"]), (
+        "Mismatch in spikes for node 'lif' with time unit conversion"
+    )


### PR DESCRIPTION
With this PR I propose to add NIRData conversion functionalities to the NIRTorch repo. For many PyTorch-based simulators, the data format does not differ much and they are typically already depending on NIRTorch. Therefore I think it is sensible to add this here. Flexibility is kept by exposing the NIRData API (e.g. `dynamic_before_transition` or `dt`)
`dt` is in units of seconds for NIRData but some simulators may operate in milliseconds, why I added the `time_unit` argument. Of course one could just convert `dt` accordingly but this might be a nicer way of doing it. But no hard opinions there.

This PR depends on the [most recent NIR PR](https://github.com/neuromorphs/NIR/pull/194).